### PR TITLE
Fix compatibility issues with MPS on Apple silicon

### DIFF
--- a/mobile_sam/automatic_mask_generator.py
+++ b/mobile_sam/automatic_mask_generator.py
@@ -277,7 +277,7 @@ class SamAutomaticMaskGenerator:
                 raise NotImplementedError()
             keep_by_nms = batched_nms(
                 data["boxes"].float(),
-                scores.to(data["boxes"].device),
+                scores.to(data["boxes"].device).float(),
                 torch.zeros_like(data["boxes"][:, 0]),  # categories
                 iou_threshold=self.box_nms_thresh,
             )

--- a/mobile_sam/utils/amg.py
+++ b/mobile_sam/utils/amg.py
@@ -332,16 +332,16 @@ def batched_mask_to_box(masks: torch.Tensor) -> torch.Tensor:
     # Get top and bottom edges
     in_height, _ = torch.max(masks, dim=-1)
     in_height_coords = in_height * torch.arange(h, device=in_height.device)[None, :]
-    bottom_edges, _ = torch.max(in_height_coords, dim=-1)
+    bottom_edges, _ = torch.max(in_height_coords.int(), dim=-1)
     in_height_coords = in_height_coords + h * (~in_height)
-    top_edges, _ = torch.min(in_height_coords, dim=-1)
+    top_edges, _ = torch.min(in_height_coords.int(), dim=-1)
 
     # Get left and right edges
     in_width, _ = torch.max(masks, dim=-2)
     in_width_coords = in_width * torch.arange(w, device=in_width.device)[None, :]
-    right_edges, _ = torch.max(in_width_coords, dim=-1)
+    right_edges, _ = torch.max(in_width_coords.int(), dim=-1)
     in_width_coords = in_width_coords + w * (~in_width)
-    left_edges, _ = torch.min(in_width_coords, dim=-1)
+    left_edges, _ = torch.min(in_width_coords.int(), dim=-1)
 
     # If the mask is empty the right edge will be to the left of the left edge.
     # Replace these boxes with [0, 0, 0, 0]

--- a/mobile_sam/utils/transforms.py
+++ b/mobile_sam/utils/transforms.py
@@ -39,7 +39,7 @@ class ResizeLongestSide:
         new_h, new_w = self.get_preprocess_shape(
             original_size[0], original_size[1], self.target_length
         )
-        coords = deepcopy(coords).astype(float)
+        coords = deepcopy(coords).astype(np.float32)
         coords[..., 0] = coords[..., 0] * (new_w / old_w)
         coords[..., 1] = coords[..., 1] * (new_h / old_h)
         return coords


### PR DESCRIPTION
# Overview

This PR solves the following errors:

- TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework doesn't support float64. Please use float32 instead.
- RuntimeError: MPS does not support min/max ops with int64 input
- NotImplementedError: The operator 'torchvision::nms' is not currently implemented for the MPS device. If you want this op to be added in priority during the prototype phase of this feature, please comment on https://github.com/pytorch/pytorch/issues/77764. As a temporary fix, you can set the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to use the CPU as a fallback for this op. WARNING: this will be slower than running natively on MPS.
- RuntimeError: dets should have the same type as scores

#  Note
It still gives the following warnings.

```
/Users/user/Repositories/MobileSAM/mobile_sam/modeling/mask_decoder.py:126: UserWarning: MPS: no support for int64 repeats mask, casting it to int32 (Triggered internally at /Users/runner/work/pytorch/pytorch/pytorch/aten/src/ATen/native/mps/operations/Repeat.mm:236.)
  src = torch.repeat_interleave(image_embeddings, tokens.shape[0], dim=0)
[W MPSFallback.mm:11] Warning: The operator 'torchvision::nms' is not currently supported on the MPS backend and will fall back to run on the CPU. This may have performance implications. (function operator())
```